### PR TITLE
fix: only use staging for the crossmint payment element temporarily:

### DIFF
--- a/src/components/MintDialog/CrossMintForm.tsx
+++ b/src/components/MintDialog/CrossMintForm.tsx
@@ -44,7 +44,7 @@ export const CrossMintForm: FC<CrossMintFormProps> = ({
       ) : null}
       <CrossmintPaymentElement
         clientId={clientId}
-        environment={environment}
+        environment={'staging'}
         recipient={{
           email: email,
           wallet: walletAddress,


### PR DESCRIPTION
## Description
Temporarily only use staging for the crossmint payment form