### PR TITLE
Fix metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -136,7 +136,7 @@ export const metadata = {
   themeColor: website.themeColor,
   openGraph: {
     title: website.title,
-    description: website.title,
+    description: website.description,
     url: 'https://onchainsummer.xyz',
     siteName: website.siteName,
     images: [website.logo],

--- a/src/config/website.ts
+++ b/src/config/website.ts
@@ -6,7 +6,7 @@ export const website = {
   url: 'https://onchainsummer.xyz',
   siteName: 'Onchain Summer',
   logo: {
-    url: '/logo.png',
+    url: 'https://onchainsummer.xyz/logo.png',
     width: 3840,
     height: 2160,
     alt: 'Onchain Summer',


### PR DESCRIPTION
 - `og:description` was pulling from the title
 - `image` meta tags were using localhost... fixed by using absolute URL