### PR TITLE
Switch "TX failed" to "Mint for free"

### DIFF
--- a/src/components/MintDialog/MintDialog.tsx
+++ b/src/components/MintDialog/MintDialog.tsx
@@ -87,8 +87,6 @@ export const MintDialog: FC = () => {
 
   const buttonTitle = useMemo(() => {
     switch (page) {
-      case ModalPage.MINT_ERROR:
-        return 'Tx Failed'
       case ModalPage.MINT_SUCCESS:
         return 'Success'
       case ModalPage.NATIVE_MINT_PENDING_CONFIRMATION:
@@ -98,6 +96,7 @@ export const MintDialog: FC = () => {
         return 'Minting...'
       case ModalPage.BRIDGE:
       case ModalPage.NATIVE_MINT:
+      case ModalPage.MINT_ERROR:
         return (
           <>
             {trendingPageNativeMint ? (


### PR DESCRIPTION
Currently if the mint fails, it says "TX failed". Just showing "Mint for free" is better so the user can retry.

![image (37)](https://github.com/base-org/onchainsummer.xyz/assets/1538523/f91f729c-1e78-47a8-b1cc-18da90303864)
