### PR TITLE
fix: set schedule time to 1600UTC for Past checks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,7 +174,10 @@ async function getPageData(spoofDate?: string) {
   const featuredPartner = schedule[today] || schedule[Object.keys(schedule)[0]]
 
   const tabs: TabsComponentProps = Object.keys(schedule).reduce((acc, date) => {
-    const comparison = compareAsc(now, new Date(date).getTime())
+    const scheduleDate = new Date(date)
+    scheduleDate.setUTCHours(16)
+
+    const comparison = compareAsc(now, scheduleDate.getTime())
     const partner = schedule[date]
 
     if (comparison === 0 || typeof partner === 'undefined') {


### PR DESCRIPTION
## Description

Updated date comparison for upcoming/past mints to consider the launch time of 1600 UTC instead of defaulting to 0000 UTC

## Ticket(s)

- [69](https://github.com/LazerTechnologies/onchain-summer/issues/69)

## Deploy Notes

Notes regarding deployment of the contained body of work. These should note any
db migrations, nginx routes, infrastructure changes, and anything that must be done before deployment.

- [ ] Need to add environment variables
  - `ENV_VAR=`

## Screenshots (if appropriate)

<!--- drag&drop screenshots here -->
