### PR TITLE
fix: add overflow-x-hidden to body

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -183,7 +183,7 @@ export default function RootLayout({
   return (
     // we should be able to remove thirdweb here, but I am leaving for now
     <ThirdWebProviderClient>
-      <html lang="en" className="flex flex-col h-full">
+      <html lang="en" className="flex flex-col h-full overflow-x-hidden">
         <body
           className={clsx(
             'flex flex-col h-full',


### PR DESCRIPTION
One of the main cards is blowing out `<body>` so this adds a `overflow-x-hidden` to remove the horizontal scrollbar.

![image](https://github.com/base-org/onchainsummer.xyz/assets/371516/e1f7e381-2057-4501-963c-52d943d48115)
