### PR TITLE
fix: use video tags for mp4 files

### DIFF
--- a/src/components/NFTAsset/NFTAsset.tsx
+++ b/src/components/NFTAsset/NFTAsset.tsx
@@ -11,7 +11,8 @@ interface NFTAssetProps {
 }
 
 export const NFTAsset: FC<NFTAssetProps> = ({ source, name, autoPlay, ...props }) => {
-  return source.indexOf('.mov') > -1 ? (
+  const extension = source.split('.').pop();
+  return extension && ['mov', 'mp4'].includes(extension) ? (
     <video loop playsInline muted autoPlay={!!autoPlay} {...props}>
       <source src={source} type="video/mp4" />
     </video>


### PR DESCRIPTION
## Description

Use video tags for MP4 files (in case we support uncompressed / unconverted videos for Anotherblock and other partners)

## Deploy Notes

Notes regarding deployment of the contained body of work. These should note any
db migrations, nginx routes, infrastructure changes, and anything that must be done before deployment.

- [ ] Need to add environment variables
  - `ENV_VAR=`

## Screenshots (if appropriate)

<!--- drag&drop screenshots here -->
