### PR TITLE
feat: allow openSeaLink for post drop collect

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -59,7 +59,12 @@ const Page = async ({ params, searchParams }: Props) => {
                   <ul className="flex flex-row gap-8 last:pr-4">
                     {remainingDrops.map((drop) => (
                       <li key={drop.name} className="flex flex-col">
-                        <DropCard {...drop} partner={name} partnerIcon={icon} />
+                        <DropCard
+                          {...drop}
+                          partner={name}
+                          partnerIcon={icon}
+                          openSeaLink={drop.openSeaLink}
+                        />
                       </li>
                     ))}
                   </ul>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,6 +77,7 @@ const Home = async ({ searchParams }: Props) => {
                             {...drop}
                             partner={name}
                             partnerIcon={icon}
+                            openSeaLink={drop.openSeaLink}
                           />
                         </li>
                       ))}

--- a/src/components/CollectButton/CollectButton.tsx
+++ b/src/components/CollectButton/CollectButton.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react'
+import { Button, ButtonProps } from '../Button'
+import { RightArrow } from '../icons/RightArrow'
+
+interface CollectButtonProps {
+  size?: ButtonProps['size']
+  address: string
+  openSeaLink?: string
+}
+
+export const CollectButton: FC<CollectButtonProps> = ({
+  size,
+  address,
+  openSeaLink,
+}) => {
+  const href =
+    openSeaLink || `https://nft.coinbase.com/collection/base/${address}`
+  return (
+    <Button size={size} href={href} external>
+      <>
+        Collect <RightArrow fill="white" className="ml-auto" />
+      </>
+    </Button>
+  )
+}

--- a/src/components/DropCard/DropCard.tsx
+++ b/src/components/DropCard/DropCard.tsx
@@ -21,6 +21,7 @@ type DropCardProps = {
   price: string
   creator: string
   mintType?: MintType
+  openSeaLink?: string
 }
 
 export const DropCard: FC<DropCardProps> = ({
@@ -36,6 +37,7 @@ export const DropCard: FC<DropCardProps> = ({
   startDate,
   endDate,
   mintType,
+  openSeaLink,
 }) => {
   const {
     isExternalLink,
@@ -80,6 +82,7 @@ export const DropCard: FC<DropCardProps> = ({
             startDate={startDate}
             partner={partner}
             contractAddress={address}
+            openSeaLink={openSeaLink}
             className="!flex !justify-center mt-auto"
           />
         ) : (
@@ -96,6 +99,7 @@ export const DropCard: FC<DropCardProps> = ({
             mintType={
               mintType || (externalLink ? MintType.External : MintType.ThirdWeb)
             }
+            openSeaLink={openSeaLink}
           />
         )}
       </div>

--- a/src/components/ExternalDrop/ExternalDrop.tsx
+++ b/src/components/ExternalDrop/ExternalDrop.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react'
 import { useValidateExternalLink } from './useValidateExternalLink'
 import { Button } from '../Button'
-import { RightArrow } from '../icons/RightArrow'
+
+import { CollectButton } from '../CollectButton/CollectButton'
 
 export interface ExternalDropProps {
   externalLink?: string
@@ -10,6 +11,7 @@ export interface ExternalDropProps {
   partner: string
   contractAddress: string
   className?: string
+  openSeaLink?: string
 }
 
 export const ExternalDrop: FC<ExternalDropProps> = ({
@@ -25,13 +27,10 @@ export const ExternalDrop: FC<ExternalDropProps> = ({
 
   if (status === 'ended') {
     return (
-      <Button
-        href={`https://nft.coinbase.com/collection/base/${props.contractAddress}`}
-        external
-        className={className}
-      >
-        Collect <RightArrow fill="white" className="ml-auto" />
-      </Button>
+      <CollectButton
+        address={props.contractAddress}
+        openSeaLink={props.openSeaLink}
+      />
     )
   }
 

--- a/src/components/MintButton/MintButton.tsx
+++ b/src/components/MintButton/MintButton.tsx
@@ -7,10 +7,10 @@ import { MintDialogContextType } from '../MintDialog/Context/Context'
 import { useValidate } from './useValidate'
 import { Button, ButtonProps } from '../Button'
 import { Loading } from '../icons/Loading'
-import clsx from 'clsx'
+
 import { useAccount } from 'wagmi'
 import { getNow } from '@/utils/getNow'
-import { RightArrow } from '../icons/RightArrow'
+import { CollectButton } from '../CollectButton/CollectButton'
 
 interface MintButtonProps extends MintDialogContextType {
   size?: ButtonProps['size']
@@ -29,15 +29,11 @@ export const MintButton: FC<MintButtonProps> = ({ size, ...mintProps }) => {
 
   if (mintProps.endDate && now >= mintProps.endDate) {
     return (
-      <Button
+      <CollectButton
         size={size}
-        href={`https://nft.coinbase.com/collection/base/${mintProps.address}`}
-        external
-      >
-        <>
-          Collect <RightArrow fill="white" className="ml-auto" />
-        </>
-      </Button>
+        address={mintProps.address}
+        openSeaLink={mintProps.openSeaLink}
+      />
     )
   }
 

--- a/src/components/MintDialog/Context/Context.ts
+++ b/src/components/MintDialog/Context/Context.ts
@@ -18,6 +18,7 @@ export interface MintDialogContextType {
   trendingPageNativeMint?: boolean
   mintButtonStyles?: string
   maxClaimablePerWallet?: string
+  openSeaLink?: string
 }
 
 export const MintDialogContext = createContext<MintDialogContextType>({
@@ -28,5 +29,5 @@ export const MintDialogContext = createContext<MintDialogContextType>({
   dropImage: '',
   dropName: '',
   creatorAddress: '',
-  mintType: MintType.ThirdWeb
+  mintType: MintType.ThirdWeb,
 })

--- a/src/components/PartnerHero/PartnerHero.tsx
+++ b/src/components/PartnerHero/PartnerHero.tsx
@@ -4,7 +4,6 @@ import ReactMarkdown from 'react-markdown'
 import { Drop, Partner } from '@/config/partners/types'
 import Image from 'next/image'
 import { FC } from 'react'
-import clsx from 'clsx'
 import { MintButton } from '../MintButton/MintButton'
 import { AddressPill } from '../AddressPill'
 import { Countdown } from '@/components/Countdown'
@@ -64,6 +63,7 @@ export const PartnerHero: FC<PartnerHeroProps> = ({
                 {...headline}
                 partner={name}
                 contractAddress={headline.address}
+                openSeaLink={headline.openSeaLink}
               />
             ) : (
               <MintButton
@@ -82,6 +82,7 @@ export const PartnerHero: FC<PartnerHeroProps> = ({
                     ? MintType.External
                     : MintType.ThirdWeb)
                 }
+                openSeaLink={headline.openSeaLink}
               />
             )}
           </>

--- a/src/config/partners/fwb.ts
+++ b/src/config/partners/fwb.ts
@@ -24,6 +24,7 @@ const fwb: Partner = {
       address: '0xc9Cca8E570F81a7476760279B5B19cc1130B7580',
       crossMintClientId: '260f26bf-8c57-43d3-a118-cc162ca10e99',
       mintType: MintType.ThirdWeb,
+      openSeaLink: 'https://opensea.io/collection/deekay-motion-new-era-eth',
       description: `In partnership with Cozomo de’ Medici, DeeKay Motion releases his first ever open edition works as the inaugural art mint on BASE.
 
 New Era is a celebration of the inevitable future where crypto will be currency and art will be digital.
@@ -41,6 +42,7 @@ New Era (ETH) and New Era (BTC) together form the New Era Set. Collect both work
       address: '0x05b8ee5658F3AD6C268C08B7A70f2FB4B10cf348',
       crossMintClientId: '194a2db0-edd9-4e4e-ac28-6ca23697fd5a',
       mintType: MintType.ThirdWeb,
+      openSeaLink: 'https://opensea.io/collection/deekay-motion-new-era-btc',
       description: `In partnership with Cozomo de’ Medici, DeeKay Motion releases his first ever open edition works as the inaugural art mint on BASE.
 
 New Era is a celebration of the inevitable future where crypto will be currency and art will be digital.

--- a/src/config/partners/types.ts
+++ b/src/config/partners/types.ts
@@ -18,6 +18,9 @@ export interface Drop {
   // TODO, consider requiring mint type
   mintType?: MintType
   description?: string
+
+  // TODO: Temp fix
+  openSeaLink?: string
 }
 
 export interface Partner {


### PR DESCRIPTION
## Description
This PR allows drops to specify an `openSeaLink` which will be used in preference of the `nft.coinbase.com/collection/` URL  after a drop has ended in the Collect button

## Ticket
N/A