### PR TITLE
feat: make context stateful and add dataSuffix option

### DIFF
--- a/src/app/trending/page.tsx
+++ b/src/app/trending/page.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx'
 import { useAccount } from 'wagmi'
 import { l2 } from '@/config/chain'
 import { getTrendingData } from '@/utils/getTrendingData'
-import { MintType } from '@/components/MintDialog/types'
+import { MintType, siteDataSuffix } from '@/components/MintDialog/types'
 import { shortenAddress } from '@/utils/address'
 
 interface QueryResult {
@@ -128,6 +128,7 @@ export default function Trending() {
                             trendingPageNativeMint={true}
                             mintButtonStyles="w-full sm:!max-w-fit"
                             mintType={MintType.MintDotFun}
+                            dataSuffix={siteDataSuffix}
                           />
                         </div>
                         <div className="grid grid-cols-4 [@media(min-width:600px)]:grid-cols-10 gap-4 items-center order-2 lg:order-3 mt-5 mb-4 md:mt-8 lg:mb-0  lg:ml-12">

--- a/src/components/DropCard/DropCard.tsx
+++ b/src/components/DropCard/DropCard.tsx
@@ -5,8 +5,9 @@ import { AddressPill } from '../AddressPill'
 import { Address } from 'wagmi'
 import { useValidateExternalLink } from '../ExternalDrop/useValidateExternalLink'
 import { ExternalDrop } from '../ExternalDrop/ExternalDrop'
-import { MintType } from '@/components/MintDialog/types'
+import { MintType, siteDataSuffix } from '@/components/MintDialog/types'
 import { NFTAsset } from '@/components/NFTAsset'
+import { Hex } from 'viem'
 
 type DropCardProps = {
   address: Address
@@ -23,6 +24,7 @@ type DropCardProps = {
   mintType?: MintType
   openSeaLink?: string
   interactWithNFTLink?: string
+  dataSuffix?: Hex
 }
 
 export const DropCard: FC<DropCardProps> = ({
@@ -40,6 +42,7 @@ export const DropCard: FC<DropCardProps> = ({
   mintType,
   openSeaLink,
   interactWithNFTLink,
+  dataSuffix
 }) => {
   const {
     isExternalLink,
@@ -105,6 +108,7 @@ export const DropCard: FC<DropCardProps> = ({
               }
               openSeaLink={openSeaLink}
               interactWithNFTLink={interactWithNFTLink}
+              dataSuffix={dataSuffix || siteDataSuffix}
             />
           )}
         </div>

--- a/src/components/MintButton/MintButton.tsx
+++ b/src/components/MintButton/MintButton.tsx
@@ -3,7 +3,7 @@
 import { FC } from 'react'
 import { ConnectDialog } from '../ConnectDialog'
 import { MintDialog } from '../MintDialog'
-import { MintDialogContextType } from '../MintDialog/Context/Context'
+import { MintDialogInfo} from '../MintDialog/Context/Context'
 import { useValidate } from './useValidate'
 import { Button, ButtonProps } from '../Button'
 import { Loading } from '../icons/Loading'
@@ -12,7 +12,7 @@ import { useAccount } from 'wagmi'
 import { getNow } from '@/utils/getNow'
 import { CollectButton } from '../CollectButton/CollectButton'
 
-interface MintButtonProps extends MintDialogContextType {
+interface MintButtonProps extends MintDialogInfo {
   size?: ButtonProps['size']
 }
 
@@ -63,7 +63,7 @@ export const MintButton: FC<MintButtonProps> = ({ size, ...mintProps }) => {
     )
   }
 
-  const props: MintDialogContextType = { ...mintProps, price: price.toString() }
+  const props: MintDialogInfo = { ...mintProps, price: price.toString() }
 
   return (
     <MintDialog

--- a/src/components/MintDialog/Context/Context.ts
+++ b/src/components/MintDialog/Context/Context.ts
@@ -1,9 +1,10 @@
 import { MintStatus } from '@/utils/mintDotFunTypes'
-import { createContext } from 'react'
+import { Dispatch, SetStateAction, createContext } from 'react'
 import { Address } from 'wagmi'
 import { MintType } from '../types'
+import { Hex } from 'viem'
 
-export interface MintDialogContextType {
+export interface MintDialogInfo {
   address: Address
   crossMintClientId?: string
   price: string
@@ -20,15 +21,15 @@ export interface MintDialogContextType {
   maxClaimablePerWallet?: string
   openSeaLink?: string
   interactWithNFTLink?: string
+  dataSuffix: Hex
 }
 
-export const MintDialogContext = createContext<MintDialogContextType>({
-  address: '0x0',
-  price: '',
-  partnerIcon: '',
-  partnerName: '',
-  dropImage: '',
-  dropName: '',
-  creatorAddress: '',
-  mintType: MintType.ThirdWeb,
-})
+type MintDialogContextType = {
+  info: MintDialogInfo,
+  setInfo: Dispatch<SetStateAction<MintDialogInfo>>
+}
+
+export const MintDialogContext = createContext<
+  MintDialogContextType | undefined
+>(undefined);
+

--- a/src/components/MintDialog/Context/Provider.tsx
+++ b/src/components/MintDialog/Context/Provider.tsx
@@ -1,7 +1,7 @@
-import { FC } from 'react'
-import { MintDialogContext, MintDialogContextType } from './Context'
+import { FC, useState } from 'react'
+import { MintDialogContext, MintDialogInfo } from './Context'
 
-interface MintDialogProviderProps extends MintDialogContextType {
+interface MintDialogProviderProps extends MintDialogInfo {
   children: React.ReactNode
 }
 
@@ -9,8 +9,10 @@ export const Provider: FC<MintDialogProviderProps> = ({
   children,
   ...context
 }) => {
+  const [info, setInfo] = useState<MintDialogInfo>(context)
+
   return (
-    <MintDialogContext.Provider value={{ ...context }}>
+    <MintDialogContext.Provider value={{info, setInfo}}>
       {children}
     </MintDialogContext.Provider>
   )

--- a/src/components/MintDialog/MintDialog.tsx
+++ b/src/components/MintDialog/MintDialog.tsx
@@ -33,7 +33,7 @@ enum FundsStatus {
 }
 
 export const MintDialog: FC<{ size?: ButtonProps['size'] }> = ({ size }) => {
-  const { price, crossMintClientId, trendingPageNativeMint, mintButtonStyles } =
+  const { info: {price, crossMintClientId, trendingPageNativeMint, mintButtonStyles} } =
     useMintDialogContext()
 
   const [open, setOpen] = useState(false)

--- a/src/components/MintDialog/elements/Layout.tsx
+++ b/src/components/MintDialog/elements/Layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
 }
 
 export const Layout: FC<LayoutProps> = ({ children }) => {
-  const { dropImage, dropName } = useMintDialogContext()
+  const { info: {dropImage, dropName} } = useMintDialogContext()
   return (
     <div className="relative grid gap-4 lg:grid-cols-2 lg:gap-16 h-full">
       <div className="relative z-20 w-full aspect-video lg:aspect-square mb-1 lg:mb-0">

--- a/src/components/MintDialog/elements/MintDotFunMinter.tsx
+++ b/src/components/MintDialog/elements/MintDotFunMinter.tsx
@@ -21,7 +21,7 @@ export const MintDotFunMinter: FC<MintDotFunMinterProps> = ({
   setTxDetails,
   totalPrice,
 }) => {
-  const { mintDotFunStatus } = useMintDialogContext()
+  const { info: {mintDotFunStatus} } = useMintDialogContext()
   const logEvent = useLogEvent()
 
   if (!mintDotFunStatus) {

--- a/src/components/MintDialog/elements/PartnerInfo.tsx
+++ b/src/components/MintDialog/elements/PartnerInfo.tsx
@@ -3,7 +3,7 @@ import { useMintDialogContext } from '../Context/useMintDialogContext'
 import Image from 'next/image'
 
 export const PartnerInfo: FC = () => {
-  const { partnerIcon, partnerName, mintDotFunStatus } = useMintDialogContext()
+  const { info: {partnerIcon, partnerName, mintDotFunStatus} } = useMintDialogContext()
 
   if (!!mintDotFunStatus) {
     return null

--- a/src/components/MintDialog/elements/Quantity.tsx
+++ b/src/components/MintDialog/elements/Quantity.tsx
@@ -9,7 +9,7 @@ interface QuantityProps {
 }
 const buttonClassName = 'py-1.5 px-4 rounded-[100px] border border-[#EFEFEF]'
 export const Quantity: FC<QuantityProps> = ({ quantity, setQuantity }) => {
-  const { maxClaimablePerWallet } = useMintDialogContext()
+  const { info: {maxClaimablePerWallet} } = useMintDialogContext()
 
   // zora has 2^32 max, thirdweb 2^256, in any case 2^32 is a lot and effectively no limit.
   if (

--- a/src/components/MintDialog/elements/usePriceEstimate.ts
+++ b/src/components/MintDialog/elements/usePriceEstimate.ts
@@ -7,7 +7,7 @@ import { useAccount } from 'wagmi'
 
 export const usePriceEstimate = () => {
   const {address} = useAccount()
-  const { price } = useMintDialogContext()
+  const { info: {price} } = useMintDialogContext()
 
   const [response, setResponse] = useState<
     Awaited<ReturnType<typeof getPriceEstimate>>

--- a/src/components/MintDialog/index.tsx
+++ b/src/components/MintDialog/index.tsx
@@ -1,10 +1,10 @@
 import { MintDialog } from './MintDialog'
-import { MintDialogContextType } from './Context/Context'
+import { MintDialogInfo } from './Context/Context'
 import { Provider } from './Context/Provider'
 import { FC } from 'react'
 import { ButtonProps } from '../Button'
 
-const Wrapper: FC<MintDialogContextType & { size?: ButtonProps['size'] }> = ({
+const Wrapper: FC<MintDialogInfo & { size?: ButtonProps['size'] }> = ({
   size,
   ...context
 }) => {

--- a/src/components/MintDialog/pages/CrossMint/CrossMintForm.tsx
+++ b/src/components/MintDialog/pages/CrossMint/CrossMintForm.tsx
@@ -41,9 +41,10 @@ export const CrossMintForm: FC<CrossMintFormProps> = ({
   totalPrice,
 }) => {
   const {
-    mintType,
+    info:
+    {mintType,
     crossMintClientId: clientId,
-    creatorAddress,
+    creatorAddress}
   } = useMintDialogContext()
   const [prepared, setPrepared] = useState(false)
   const paymentProcessing = page === ModalPage.CROSS_MINT_PENDING

--- a/src/components/MintDialog/pages/InsufficientFunds/InsufficientFunds.tsx
+++ b/src/components/MintDialog/pages/InsufficientFunds/InsufficientFunds.tsx
@@ -57,7 +57,7 @@ export const InsufficientFunds: FC<InsufficientFundsProps> = ({
   setPage,
   totalPrice,
 }) => {
-  const { crossMintClientId } = useMintDialogContext()
+  const { info: {crossMintClientId} } = useMintDialogContext()
   usePollBalance(setPage, totalPrice)
 
   if (!crossMintClientId) {

--- a/src/components/MintDialog/pages/NativeMint/NativeMint.tsx
+++ b/src/components/MintDialog/pages/NativeMint/NativeMint.tsx
@@ -42,7 +42,7 @@ export const NativeMint: FC<NativeMintProps> = ({
   const network = useNetwork()
 
   const wrongChain = network.chain?.id !== l2.id
-  const { creatorAddress, dropName, crossMintClientId, mintDotFunStatus } =
+  const { info: {creatorAddress, dropName, crossMintClientId, mintDotFunStatus} } =
     useMintDialogContext()
   const isPendingConfirmation =
     page === ModalPage.NATIVE_MINT_PENDING_CONFIRMATION

--- a/src/components/MintDialog/pages/Success/Success.tsx
+++ b/src/components/MintDialog/pages/Success/Success.tsx
@@ -22,7 +22,7 @@ export const Success: FC<SuccessProps> = ({
   txHash,
   closeModal,
 }) => {
-  const { dropName, creatorAddress, interactWithNFTLink } =
+  const { info: {dropName, creatorAddress, interactWithNFTLink} } =
     useMintDialogContext()
   return (
     <>

--- a/src/components/MintDialog/types.ts
+++ b/src/components/MintDialog/types.ts
@@ -1,3 +1,5 @@
+import { Hex, keccak256, toHex } from "viem";
+
 export enum ModalPage {
   NATIVE_MINT,
   NATIVE_MINT_PENDING_CONFIRMATION,
@@ -19,3 +21,6 @@ export enum MintType {
   MintDotFun = 'mint.fun',
   External = 'external'
 }
+
+// 0x + first 8 characters / 4 bytes to append to calldata 
+export const siteDataSuffix: Hex = keccak256(toHex('onchainsummer.xyz')).slice(0, 10) as Hex;

--- a/src/components/PartnerHero/PartnerHero.tsx
+++ b/src/components/PartnerHero/PartnerHero.tsx
@@ -10,7 +10,7 @@ import { Countdown } from '@/components/Countdown'
 import { Address } from 'viem'
 import { NFTAsset } from '@/components/NFTAsset'
 import { ExternalDrop } from '../ExternalDrop/ExternalDrop'
-import { MintType } from '@/components/MintDialog/types'
+import { MintType, siteDataSuffix } from '@/components/MintDialog/types'
 
 interface PartnerHeroProps {
   partner: Partner
@@ -85,6 +85,7 @@ export const PartnerHero: FC<PartnerHeroProps> = ({
                 }
                 openSeaLink={headline.openSeaLink}
                 interactWithNFTLink={headline.interactWithNFTLink}
+                dataSuffix={headline.dataSuffix || siteDataSuffix}
               />
             )}
           </>

--- a/src/components/Share/Share.tsx
+++ b/src/components/Share/Share.tsx
@@ -12,7 +12,7 @@ const lensURL: string = 'https://lenster.xyz'
 
 type ShareComponentProps = {}
 export const Share: FC<ShareComponentProps> = () => {
-  const { dropName } = useMintDialogContext()
+  const { info: {dropName} } = useMintDialogContext()
   const {
     location: { href },
   } = window

--- a/src/components/Trending/Trending.tsx
+++ b/src/components/Trending/Trending.tsx
@@ -20,7 +20,7 @@ import { shortenAddress } from '@/utils/address'
 import { useAccount } from 'wagmi'
 import { l2 } from '@/config/chain'
 import { getTrendingData } from '@/utils/getTrendingData'
-import { MintType } from '@/components/MintDialog/types'
+import { MintType, siteDataSuffix } from '@/components/MintDialog/types'
 
 export interface TrendingComponentProps {}
 
@@ -162,6 +162,7 @@ export const Trending: FC<TrendingComponentProps> = () => {
                         trendingPageNativeMint={true}
                         mintButtonStyles="w-1/3 sm:!max-w-fit"
                         mintType={MintType.MintDotFun}
+                        dataSuffix={siteDataSuffix}
                       />
                     </div>
                   </div>

--- a/src/config/partners/types.ts
+++ b/src/config/partners/types.ts
@@ -1,4 +1,5 @@
 import { MintType } from '@/components/MintDialog/types'
+import { Hex } from 'viem'
 
 export const DAY = 1000 * 60 * 60 * 24
 
@@ -22,6 +23,7 @@ export interface Drop {
   // TODO: Temp fix
   openSeaLink?: string
   interactWithNFTLink?: string
+  dataSuffix?: Hex
 }
 
 export interface Partner {

--- a/src/utils/useMintThresholds.ts
+++ b/src/utils/useMintThresholds.ts
@@ -5,7 +5,7 @@ export const l2GasToMint = parseEther('0.0006')
 export const l1GasToBridge = parseEther('0.01')
 
 export function useMintThresholds() {
-    const {price} = useMintDialogContext();
+    const {info : {price}} = useMintDialogContext();
     const priceWei = parseEther(price);
 
     return {


### PR DESCRIPTION
## Description

In this PR I update mintDialogContext to be stateful, so that certain of its values can be set within the dialog flow, and also add a dataSuffix to the mint which is only used for third web currently. 

## Deploy Notes

Notes regarding deployment of the contained body of work. These should note any
db migrations, nginx routes, infrastructure changes, and anything that must be done before deployment.

- [ ] Need to add environment variables
  - `ENV_VAR=`

## Screenshots (if appropriate)

<!--- drag&drop screenshots here -->
