### PR TITLE
chore: fix mint button overflow on safari partner hero

### DIFF
--- a/src/components/PartnerHero/PartnerHero.tsx
+++ b/src/components/PartnerHero/PartnerHero.tsx
@@ -36,7 +36,7 @@ export const PartnerHero: FC<PartnerHeroProps> = ({
           className="object-cover rounded-xl"
         />
       </div>
-      <div className="inline-flex flex-col w-full gap-4 h-max order-2 md:h-full md:order-1 md:gap-4 overflow-x-scroll overflow-y-visible">
+      <div className="inline-flex flex-col w-full gap-4 h-max order-2 md:h-auto md:order-1 md:gap-4">
         {name !== 'Base' && (
           <div className="flex gap-2 md:mt-6">
             <div className="relative h-6 w-6">


### PR DESCRIPTION
## Description

- PartnerHero mint button was overflowing it's container
- The PartnerHero also had a small horizontal scroll bar below the button, fixed this as well

## Deploy Notes

Notes regarding deployment of the contained body of work. These should note any
db migrations, nginx routes, infrastructure changes, and anything that must be done before deployment.

- [ ] Need to add environment variables
  - `ENV_VAR=`

## Screenshots (if appropriate)

## Small scroll bar below button:
![Screen Shot 2023-08-11 at 5 29 13 PM](https://github.com/base-org/onchainsummer.xyz/assets/22405289/18d26154-5079-49c3-8bf7-d1ff378f5bcb)


## Before:
![Screen Shot 2023-08-11 at 5 23 30 PM](https://github.com/base-org/onchainsummer.xyz/assets/22405289/61370daf-d952-43e2-9bc4-d341cde4cf55)

## After:
![Screen Shot 2023-08-11 at 5 18 11 PM](https://github.com/base-org/onchainsummer.xyz/assets/22405289/32350c6a-e2e2-43e2-84ca-bea9e68bf363)


