### PR TITLE
chore: using moment timezone to sync server and frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "graphql-request": "^6.1.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
+    "moment-timezone": "^0.5.43",
     "next": "13.4.13",
     "next-query-params": "^4.2.2",
     "nuka-carousel": "^6.0.3",

--- a/src/utils/getDropDate.ts
+++ b/src/utils/getDropDate.ts
@@ -4,6 +4,7 @@ import { getNow } from './getNow'
 export const getDropDate = (spoofDate?: string | null) => {
   const now = getNow(spoofDate)
   const date = moment.tz(now, 'America/New_York')
-  const dateToReturn = date.get('hour') >= 12 ? date : date.subtract(1, 'day')
-  return dateToReturn.format('YYYY-MM-DD')
+  return date.get('hour') >= 12
+    ? date.format('YYYY-MM-DD')
+    : date.subtract(1, 'day').format('YYYY-MM-DD')
 }

--- a/src/utils/getDropDate.ts
+++ b/src/utils/getDropDate.ts
@@ -4,9 +4,6 @@ import { getNow } from './getNow'
 export const getDropDate = (spoofDate?: string | null) => {
   const now = getNow(spoofDate)
   const date = moment.tz(now, 'America/New_York')
-  const dateToReturn =
-    date.get('hour') >= 12
-      ? date.format('YYYY-MM-DD')
-      : date.subtract(1, 'day').format('YYYY-MM-DD')
-  return dateToReturn
+  const dateToReturn = date.get('hour') >= 12 ? date : date.subtract(1, 'day')
+  return dateToReturn.format('YYYY-MM-DD')
 }

--- a/src/utils/getDropDate.ts
+++ b/src/utils/getDropDate.ts
@@ -1,17 +1,12 @@
+import moment from 'moment-timezone'
 import { getNow } from './getNow'
-
-const padNumber = (num: number) => {
-  return num < 10 ? `0${num}` : num
-}
 
 export const getDropDate = (spoofDate?: string | null) => {
   const now = getNow(spoofDate)
-  const date = new Date(now)
-  const year = date.getUTCFullYear()
-  const month = padNumber(date.getUTCMonth() + 1)
-  const hours = date.getUTCHours()
-  const day = hours >= 16 ? date.getUTCDate() : date.getUTCDate() - 1
-
-  const today = `${year}-${month}-${padNumber(day)}`
-  return today
+  const date = moment.tz(now, 'America/New_York')
+  const dateToReturn =
+    date.get('hour') >= 12
+      ? date.format('YYYY-MM-DD')
+      : date.subtract(1, 'day').format('YYYY-MM-DD')
+  return dateToReturn
 }

--- a/src/utils/getNow.ts
+++ b/src/utils/getNow.ts
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone'
 import isValid from 'date-fns/isValid'
 const defaultSpoofDate = process.env.NEXT_PUBLIC_SPOOF_DATE
 const ALLOW_SPOOFING = defaultSpoofDate !== undefined
@@ -19,20 +20,12 @@ export const getNow = (spoofDate?: string | null) => {
     return nowUTC
   }
 
-  const spoofedDate = value ? new Date(value) : undefined
+  const spoofedDate = moment.tz(value, 'America/New_York')
 
-  const isValidDate = isValid(spoofedDate)
+  const isValidDate = isValid(spoofedDate.toDate())
 
   if (isValidDate && spoofedDate) {
-    return Date.UTC(
-      spoofedDate.getFullYear(),
-      spoofedDate.getMonth(),
-      spoofedDate.getDate(),
-      spoofedDate.getHours(),
-      spoofedDate.getMinutes(),
-      spoofedDate.getSeconds(),
-      spoofedDate.getMilliseconds()
-    )
+    return spoofedDate.toDate().getTime()
   }
 
   return nowUTC

--- a/src/utils/getNow.ts
+++ b/src/utils/getNow.ts
@@ -14,13 +14,13 @@ const getSpoofDateFromParams = () => {
 
 export const getNow = (spoofDate?: string | null) => {
   const value = spoofDate || getSpoofDateFromParams() || defaultSpoofDate
-  const nowUTC = moment.tz(moment(), 'America/New_York').toDate().getTime()
+  const nowUTC = moment().tz('America/New_York').toDate().getTime()
 
   if (!ALLOW_SPOOFING) {
     return nowUTC
   }
 
-  const spoofedDate = moment.tz(value, 'America/New_York')
+  const spoofedDate = moment(value).tz('America/New_York')
 
   const isValidDate = isValid(spoofedDate.toDate())
 

--- a/src/utils/getNow.ts
+++ b/src/utils/getNow.ts
@@ -14,7 +14,7 @@ const getSpoofDateFromParams = () => {
 
 export const getNow = (spoofDate?: string | null) => {
   const value = spoofDate || getSpoofDateFromParams() || defaultSpoofDate
-  const nowUTC = new Date().getTime()
+  const nowUTC = moment.tz(moment(), 'America/New_York').toDate().getTime()
 
   if (!ALLOW_SPOOFING) {
     return nowUTC

--- a/yarn.lock
+++ b/yarn.lock
@@ -7703,6 +7703,13 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+moment-timezone@^0.5.43:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
+  dependencies:
+    moment "^2.29.4"
+
 moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Using a timezone-specific date constructor to sync back and front-end date and times for drops. The timezone is set to ET. 