### PR TITLE
fix: navigation menu overflow on desktop

### DIFF
--- a/src/components/Navbar/Desktop.tsx
+++ b/src/components/Navbar/Desktop.tsx
@@ -8,7 +8,7 @@ type DesktopProps = {}
 
 export const Desktop: FC<DesktopProps> = ({}) => {
   return (
-    <NavigationMenu.Root className="relative z-[1] hidden w-screen lg:flex [&>div]:w-full px-20">
+    <NavigationMenu.Root className="relative z-[1] hidden w-full lg:flex [&>div]:w-full px-20">
       <NavigationMenu.List className="flex basis-[10%] gap-[46px] justify-between  py-[18px] w-full items-center max-w-7xl mx-auto">
         <NavigationMenu.Link asChild>
           <Link href="/">


### PR DESCRIPTION
## Description

changed NavigationMenu.Root width to w-full


## Screenshots (if appropriate)
<img width="2168" alt="image" src="https://github.com/base-org/onchainsummer.xyz/assets/63567298/45cc0bb2-b94b-46da-9bc4-f0707665437e">

<!--- drag&drop screenshots here -->
