### PR TITLE
fix: apple pay don't require email

### DIFF
--- a/src/components/MintDialog/pages/CrossMint/CrossMintForm.tsx
+++ b/src/components/MintDialog/pages/CrossMint/CrossMintForm.tsx
@@ -55,6 +55,9 @@ export const CrossMintForm: FC<CrossMintFormProps> = ({
       <h3 className="my-2 font-medium text-lg">Mint with Credit Card</h3>
       <CrossmintPaymentElement
         emailInputOptions={{ show: true }}
+        experimental={{
+          useCardWalletEmail: true,
+        }}
         clientId={clientId || ''}
         environment={environment}
         recipient={{


### PR DESCRIPTION
## Description
This PR allows apple pay to be enabled without the email field being filled out