### PR TITLE
feat: add subscribe button to navbar

### DIFF
--- a/src/components/Navbar/DesktopNavListItems.tsx
+++ b/src/components/Navbar/DesktopNavListItems.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
 import Link from 'next/link'
 import { Wallet } from './Wallet'
+import { CBSubscribeDialog } from '@/components/CBSubscribeDialog'
+import { Button } from '@/components/Button'
 
 type NavListItemsProps = {}
 
@@ -44,6 +46,11 @@ export const NavListItems: FC<NavListItemsProps> = ({}) => {
         <p className="uppercase desktop-mono text-[#858585] whitespace-nowrap block min-[1184px]:block min-[1024px]:hidden">
           Get onchain this summer
         </p>
+        <NavigationMenu.Item asChild>
+          <CBSubscribeDialog>
+            <Button className="!py-1.5 !px-4">Subscribe</Button>
+          </CBSubscribeDialog>
+        </NavigationMenu.Item>
         <NavigationMenu.Item asChild>
           <Wallet />
         </NavigationMenu.Item>

--- a/src/components/Navbar/MobileNavListItems.tsx
+++ b/src/components/Navbar/MobileNavListItems.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
 import Link from 'next/link'
 import * as Dialog from '@radix-ui/react-dialog'
+import { CBSubscribeDialog } from '@/components/CBSubscribeDialog'
+import { Button } from '@/components/Button'
 
 type NavListItemsProps = {}
 
@@ -46,6 +48,15 @@ export const NavListItems: FC<NavListItemsProps> = ({}) => {
                 Community
               </Link>
             </NavigationMenu.Link>
+          </Dialog.Close>
+        </NavigationMenu.Item>
+        <NavigationMenu.Item>
+          <Dialog.Close asChild>
+            <CBSubscribeDialog>
+              <Button className="!w-auto" size="X-SMALL">
+                Subscribe
+              </Button>
+            </CBSubscribeDialog>
           </Dialog.Close>
         </NavigationMenu.Item>
       </NavigationMenu.List>


### PR DESCRIPTION
## Description
Add a `Subscribe` button to the OCS navbar on desktop and mobile. This will open a QR code to launch the user into wallet messaging (same behavior as the footer button `Subscribe with wallet`).

## Deploy Notes

Notes regarding deployment of the contained body of work. These should note any
db migrations, nginx routes, infrastructure changes, and anything that must be done before deployment.

- [ ] Need to add environment variables
  - `ENV_VAR=`

## Screenshots (if appropriate)
### Mobile
<img width="393" alt="Screen Shot 2023-08-15 at 4 11 54 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/4382148/e42fa116-1dc6-4e1d-9ad6-5cf03af3cd90">

### Desktop
<img width="1255" alt="Screen Shot 2023-08-15 at 4 12 10 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/4382148/2d9ed9f4-120a-4706-badd-6aee0e72c13c">
