### PR TITLE
feat: allow button text for 'interact with nft' to be configurable

### DIFF
--- a/src/components/DropCard/DropCard.tsx
+++ b/src/components/DropCard/DropCard.tsx
@@ -8,7 +8,7 @@ import { ExternalDrop } from '../ExternalDrop/ExternalDrop'
 import { MintType, siteDataSuffix } from '@/components/MintDialog/types'
 import { NFTAsset } from '@/components/NFTAsset'
 import { Hex } from 'viem'
-import { DropDataSuffix } from '@/config/partners/types'
+import { Drop, DropDataSuffix } from '@/config/partners/types'
 
 type DropCardProps = {
   address: Address
@@ -25,7 +25,7 @@ type DropCardProps = {
   creator: string
   mintType?: MintType
   openSeaLink?: string
-  interactWithNFTLink?: string
+  interactWithNFTLink?: Drop['interactWithNFTLink']
   dataSuffix: Hex
   dropDataSuffix?: DropDataSuffix
   buttonText?: string

--- a/src/components/MintDialog/Context/Context.ts
+++ b/src/components/MintDialog/Context/Context.ts
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction, createContext } from 'react'
 import { Address } from 'wagmi'
 import { MintType } from '../types'
 import { Hex } from 'viem'
-import { DropDataSuffix } from '@/config/partners/types'
+import { Drop, DropDataSuffix } from '@/config/partners/types'
 
 export interface MintDialogInfo {
   address: Address
@@ -21,7 +21,7 @@ export interface MintDialogInfo {
   mintButtonStyles?: string
   maxClaimablePerWallet?: string
   openSeaLink?: string
-  interactWithNFTLink?: string
+  interactWithNFTLink?: Drop['interactWithNFTLink']
   dataSuffix: Hex
   dropDataSuffix?: DropDataSuffix
 }

--- a/src/components/MintDialog/pages/Success/Success.tsx
+++ b/src/components/MintDialog/pages/Success/Success.tsx
@@ -50,8 +50,8 @@ export const Success: FC<SuccessProps> = ({
           />
         </Dialog.Close>
         {interactWithNFTLink ? (
-          <Button variant="LIGHT" external href={interactWithNFTLink}>
-            Unlock the magic of your nft
+          <Button variant="LIGHT" external href={interactWithNFTLink.url}>
+            {interactWithNFTLink.label}
           </Button>
         ) : null}
       </div>

--- a/src/config/partners/coke.ts
+++ b/src/config/partners/coke.ts
@@ -27,8 +27,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/vermeer.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x1DdB721BF79d3Ad33fBac72E5dEcf2A436CB42a3',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x1DdB721BF79d3Ad33fBac72E5dEcf2A436CB42a3',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -43,8 +45,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/aket.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x916555Cd5F02E159b84d5247F8660531A4525d2d',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x916555Cd5F02E159b84d5247F8660531A4525d2d',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -59,8 +63,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/wonder.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x32cF27F2753e90948195b64EC55C486EE640cF61',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x32cF27F2753e90948195b64EC55C486EE640cF61',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -75,8 +81,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/fatam.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0xe4c3AA3978B61431C070109629a687bc42D66d8f',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0xe4c3AA3978B61431C070109629a687bc42D66d8f',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -91,8 +99,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/vikram.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x766D25d7005e6B690C0ab4FA1e81a2eB9B416c50',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x766D25d7005e6B690C0ab4FA1e81a2eB9B416c50',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -107,8 +117,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/stefania.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x19766E9DA39ecb68b85b9B4aF3B0cE4f9a4F2ECf',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x19766E9DA39ecb68b85b9B4aF3B0cE4f9a4F2ECf',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -123,8 +135,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/munch.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x9A466C55F0cFC8Ea3cEE03DE0EB94Bf35A934522',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x9A466C55F0cFC8Ea3cEE03DE0EB94Bf35A934522',
+        label: 'Unlock the magic of your NFT',
+      },
     },
     {
       startDate: Date.UTC(2023, 7, 13, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
@@ -139,8 +153,10 @@ const cokeConfig: Partner = {
       creator: '0xb12e7dEe5af51d61114c96E50c80afC80CC26595',
       image: '/partners/coke/drop/vangogh.jpg',
       type: 'erc-721',
-      interactWithNFTLink:
-        'https://nft.coinbase.com/collection/base/0x65b2E459f779FF4af4e4A16bc8065A0063cF8221',
+      interactWithNFTLink: {
+        url: 'https://nft.coinbase.com/collection/base/0x65b2E459f779FF4af4e4A16bc8065A0063cF8221',
+        label: 'Unlock the magic of your NFT',
+      },
     },
   ],
 }

--- a/src/config/partners/types.ts
+++ b/src/config/partners/types.ts
@@ -27,7 +27,10 @@ export interface Drop {
 
   // TODO: Temp fix
   openSeaLink?: string
-  interactWithNFTLink?: string
+  interactWithNFTLink?: {
+    url: string
+    label: string
+  }
   dataSuffix?: DropDataSuffix
   buttonText?: string
 }


### PR DESCRIPTION
## Description
This PR enables the `interactWithNFTLink` to have a configurable URL/text

[ticket](https://www.notion.so/lazertechnologies/Change-Unlock-the-magic-configurable-text-to-be-a-label-value-9f5fc40ff6754bb99072263801b4c968?pvs=4)