### PR TITLE
fix: tab layout shift

### DIFF
--- a/src/components/Tabs/TabsListItems.tsx
+++ b/src/components/Tabs/TabsListItems.tsx
@@ -16,7 +16,7 @@ export const TabsListItems: FC<TabsListItemsProps> = ({
   return (
     <>
       <Tabs.Trigger
-        className="text-neutral-900 md:min-w-[200px] border-2 border-solid border-[#858585] data-[state=active]:border-none data-[state=active]:bg-[#FCD22D] px-3 pt-10 pb-2 md:px-4 rounded-2xl relative"
+        className="md:min-w-[200px] border-2 border-solid border-[#858585] radix-state-active:border-ocs-yellow radix-state-active:bg-ocs-yellow px-3 pt-10 pb-2 md:px-4 rounded-2xl relative"
         value="tab1"
       >
         <div className="flex items-center desktop-h3 md:desktop-h2">
@@ -27,7 +27,7 @@ export const TabsListItems: FC<TabsListItemsProps> = ({
         </div>
       </Tabs.Trigger>
       <Tabs.Trigger
-        className="text-neutral-900 md:min-w-[200px] border-2 border-solid border-[#858585] data-[state=active]:border-none data-[state=active]:bg-[#FCD22D] px-3 pt-10 pb-2 md:px-4 rounded-2xl relative"
+        className="md:min-w-[200px] border-2 border-solid border-[#858585] radix-state-active:border-none radix-state-active:bg-ocs-yellow px-3 pt-10 pb-2 md:px-4 rounded-2xl relative"
         value="tab2"
       >
         <div className="flex items-center desktop-h3 md:desktop-h2">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,6 +35,7 @@ module.exports = {
         'ocs-blue': '#0052FF',
         'ocs-turquoise': '#54DCE7',
         'ocs-gray': '#444444',
+        'ocs-yellow': '#FCD22D',
         'light-palette-line': 'rgba(91, 97, 110, 0.20)',
         'light-palette-line-heavy': 'rgba(91, 97, 110, 0.66)',
       },


### PR DESCRIPTION
## Description
This PR fixes the layout shift in the tabs caused by the border disappearing for selected tab

### Before
> The tabs shift by 2px every time they're switched

https://github.com/base-org/onchainsummer.xyz/assets/51837850/2ed7c297-940b-4081-993b-03d6d490419b



### After
https://github.com/base-org/onchainsummer.xyz/assets/51837850/13f6c13b-a9e1-482d-81ea-956bf1a02640