### PR TITLE
fix: remove info drops from active drops carousel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -255,7 +255,9 @@ async function getPageData(spoofDate?: string) {
 
       const active = drops.filter((drop) => {
         const comparison = compareAsc(now, drop.endDate)
-        const isInfo = drop.address === '0x0' || drop.address === '0x'
+        const isExternal = !!drop.externalLink && !drop.buttonText
+        const isInfo =
+          (drop.address === '0x0' || drop.address === '0x') && !isExternal
 
         return !isInfo && (comparison === -1 || comparison === 0)
       })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -255,8 +255,9 @@ async function getPageData(spoofDate?: string) {
 
       const active = drops.filter((drop) => {
         const comparison = compareAsc(now, drop.endDate)
+        const isInfo = drop.address === '0x0' || drop.address === '0x'
 
-        return comparison === -1 || comparison === 0
+        return !isInfo && (comparison === -1 || comparison === 0)
       })
 
       const next = active.map((drop) => ({


### PR DESCRIPTION
## Description
This PR removes info drops from the active drops carousel

https://www.notion.so/lazertechnologies/Remove-Info-Drops-from-active-carousel-that-don-t-have-a-contract-read-description-here-2efa9c00f5d24f498fdb8b4de39a593c?pvs=4

https://github.com/base-org/onchainsummer.xyz/assets/51837850/14f11821-3ae9-408d-a81c-f07352690d4c

