### PR TITLE
fix: add scrollbar to drop card list

### DIFF
--- a/src/components/DropCard/DropCardList.tsx
+++ b/src/components/DropCard/DropCardList.tsx
@@ -2,7 +2,7 @@ import { FC, PropsWithChildren } from 'react'
 
 export const DropCardList: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="overflow-auto hide-scrollbar">
+    <div className="overflow-auto">
       <div className="flex overflow-y-hidden md:overflow-x-auto w-max">
         <ul className="flex gap-4 md:gap-8 last:pr-4">{children}</ul>
       </div>


### PR DESCRIPTION
## Description
This PR puts the scrollbar back in the Drop Card List