### PR TITLE
fix: tweet card character limit logic, use lineclamp

### DIFF
--- a/src/components/TweetCard/TweetCard.tsx
+++ b/src/components/TweetCard/TweetCard.tsx
@@ -5,6 +5,7 @@ import { FunctionComponent, useMemo } from 'react'
 
 import { TwitterVerified } from '@/components/icons/TwitterVerified'
 import { ITweet, ITweetMedia, ITweetAuthor } from '@/models/Tweet'
+import clsx from 'clsx'
 
 export interface ITweetCardProps {
   author: ITweetAuthor
@@ -21,23 +22,7 @@ export const TweetCard: FunctionComponent<ITweetCardProps> = ({
     return `https://twitter.com/${author.username}/status/${tweet.id}`
   }, [author.username, tweet.id])
 
-  const message = useMemo(() => {
-    const text = tweet.text
-      // .replace(
-      //   /(?:((?<=[\s\W])|^)[#](\w+|[^#]|$)|((?<=[\s\W])|^)[@]([a-zA-Z0-9_]+|$))/gm,
-      //   '',
-      // )
-      .trim()
-    return text.length > 120
-      ? text.substring(
-          0,
-          tweet.text.indexOf(
-            ' ',
-            media ? 120 : Math.min(tweet.text.length, 240)
-          )
-        ) + '...'
-      : text
-  }, [tweet.text, media])
+  const message = tweet.text.trim()
 
   const url = useMemo(() => {
     const firstUrl = tweet?.entities?.urls?.[0]
@@ -78,7 +63,17 @@ export const TweetCard: FunctionComponent<ITweetCardProps> = ({
             </div>
           </div>
         </div>
-        <div className="mt-2">
+        <div
+          className={clsx(
+            'my-2.5',
+            {
+              'line-clamp-3': !!media,
+            },
+            {
+              'line-clamp-6': !media,
+            }
+          )}
+        >
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{


### PR DESCRIPTION
## Description
This PR fixes the tweet card character limit logic by utilizing line-clamp

<img width="1324" alt="Screen Shot 2023-08-21 at 11 49 47 AM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/54fd633d-d75e-4486-897d-b423f9f22257">
