### PR TITLE
feat: default fetch schedule from vercel build, fallback to local config

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,8 +1,5 @@
-import { get } from 'lodash'
 import { notFound, redirect } from 'next/navigation'
 import compareAsc from 'date-fns/compareAsc'
-import format from 'date-fns/format'
-import { schedule } from '@/config/schedule'
 import { PartnerHero } from '@/components/PartnerHero'
 import { ReactMarkdown } from '@/components/ReactMarkdown'
 import React from 'react'
@@ -16,6 +13,7 @@ import { getArweaveById } from '@/utils/getArweaveById'
 import { getDropDate } from '@/utils/getDropDate'
 import { siteDataSuffix } from '@/components/MintDialog/types'
 import { DropCardList } from '@/components/DropCard/DropCardList'
+import { getSchedule } from '@/utils/getSchedule'
 
 type Props = {
   params: { slug: string }
@@ -92,7 +90,7 @@ const Page = async ({ params, searchParams }: Props) => {
 
 export async function generateMetadata(
   { params, searchParams }: Props,
-  parent: ResolvingMetadata,
+  parent: ResolvingMetadata
 ): Promise<Metadata> {
   // read route params
   const slug = params.slug
@@ -143,11 +141,12 @@ export async function generateMetadata(
 }
 
 async function getPartner(slug: string, spoofDate?: string) {
-  const now = getNow(spoofDate)
   const today = getDropDate(spoofDate)
 
+  const schedule = await getSchedule()
+
   const date = Object.keys(schedule).find(
-    (date) => schedule[date].slug.toLowerCase() === slug.toLowerCase(),
+    (date) => schedule[date].slug.toLowerCase() === slug.toLowerCase()
   )
 
   if (!date) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image'
 import { Button } from '@/components/Button'
 import { DropCard } from '@/components/DropCard'
 import { PartnerHero } from '@/components/PartnerHero'
-import { schedule } from '@/config/schedule'
 import { Tabs, TabsComponentProps } from '@/components/Tabs'
 import { ReactMarkdown } from '@/components/ReactMarkdown'
 import { PageContainer } from '@/components/PageContainer'
@@ -22,6 +21,7 @@ import { siteDataSuffix } from '@/components/MintDialog/types'
 import { Drop } from '@/config/partners/types'
 import { Gift } from '@/components/icons/Gift'
 import { DropCardList } from '@/components/DropCard/DropCardList'
+import { getSchedule } from '@/utils/getSchedule'
 
 type Props = {
   searchParams: { [key: string]: string | string[] | undefined }
@@ -208,6 +208,8 @@ interface DropWithPartnerData extends Drop {
 async function getPageData(spoofDate?: string) {
   const now = getNow(spoofDate)
   const today = getDropDate(spoofDate)
+
+  const schedule = await getSchedule()
 
   const featuredPartner = schedule[today] || schedule[Object.keys(schedule)[0]]
 

--- a/src/utils/getSchedule.ts
+++ b/src/utils/getSchedule.ts
@@ -1,4 +1,18 @@
+import { Partner } from '@/config/partners/types'
 import { schedule } from '@/config/schedule'
+
+const isSchedule = (schedule: any): schedule is typeof schedule => {
+  return (
+    schedule &&
+    typeof schedule === 'object' &&
+    Object.keys(schedule).every((date) => {
+      return (
+        typeof schedule[date] === 'object' &&
+        Array.isArray(schedule[date].drops)
+      )
+    })
+  )
+}
 
 export const getSchedule = async () => {
   const fetchSchedule = await fetch(
@@ -10,7 +24,23 @@ export const getSchedule = async () => {
 
   const fetchedSchedule = (await fetchSchedule.json()) as typeof schedule
 
-  const _schedule = fetchedSchedule || schedule
+  const _schedule = isSchedule(fetchedSchedule) ? fetchedSchedule : schedule
 
-  return _schedule
+  const res = Object.keys(_schedule).reduce(
+    (acc, date) => {
+      return {
+        [date.slice(0, 10)]: {
+          ..._schedule[date],
+          drops: _schedule[date].drops.map((drop) => ({
+            ...drop,
+            startDate: new Date(drop.startDate).getTime(),
+            endDate: new Date(drop.endDate).getTime(),
+          })),
+        },
+        ...acc,
+      }
+    },
+    {} as Record<string, Partner>
+  )
+  return res
 }

--- a/src/utils/getSchedule.ts
+++ b/src/utils/getSchedule.ts
@@ -1,0 +1,16 @@
+import { schedule } from '@/config/schedule'
+
+export const getSchedule = async () => {
+  const fetchSchedule = await fetch(
+    'https://onchainsummer-xyz.vercel.app/api/schedule',
+    {
+      next: { revalidate: 1 * 60 },
+    }
+  )
+
+  const fetchedSchedule = (await fetchSchedule.json()) as typeof schedule
+
+  const _schedule = fetchedSchedule || schedule
+
+  return _schedule
+}


### PR DESCRIPTION
## Description
This PR changes the way the `schedule` config is imported.

The default is to fetch the config from the vercel build, with a fallback to the local config file.

This allows for faster config changes when waiting for deployments to build