### PR TITLE
Drop card nft asset fix

### DIFF
--- a/src/components/DropCard/DropCard.tsx
+++ b/src/components/DropCard/DropCard.tsx
@@ -69,7 +69,7 @@ export const DropCard: FC<DropCardProps> = ({
   return (
     <Card
       li
-      className="relative flex flex-col max-h-[580px] gap-4 font-text w-[290px] md:w-[320px]"
+      className="relative flex flex-col max-h-[580px] gap-4 font-text w-[290px] md:w-[320px] overflow-hidden"
     >
       <div className="relative w-full aspect-[4/3] bg-black flex items-center rounded-t-2xl md:rounded-t-3xl">
         <NFTAsset

--- a/src/components/NFTAsset/NFTAsset.tsx
+++ b/src/components/NFTAsset/NFTAsset.tsx
@@ -27,7 +27,7 @@ export const NFTAsset: FC<NFTAssetProps> = ({
       muted={!!muted}
       autoPlay={!!autoPlay}
       {...props}
-      className="z-10 relative aspect-[4/3]"
+      className="z-10 w-full h-full object-cover absolute top-0 left-0"
     >
       <source src={source} type="video/mp4" />
     </video>


### PR DESCRIPTION
## Description
This PR updates the treatment for NFT assets in both the partner hero and NFT Asset component when the assets are video

### Before
<img width="914" alt="Screen Shot 2023-08-21 at 5 36 27 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/e1e561bc-f560-4944-af1c-e6c33401ca5a">

<img width="934" alt="Screen Shot 2023-08-21 at 5 36 23 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/6c5ce6fa-fcb8-42ec-a82e-b3e2aff1cc64">

### After
<img width="926" alt="Screen Shot 2023-08-21 at 5 35 59 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/4cb6289f-b536-4aae-b23e-9339eb97d58d">
<img width="893" alt="Screen Shot 2023-08-21 at 5 36 03 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/4baa5f68-22ba-4b2e-8c99-7498d69d0bd6">
