### PR TITLE
fix: external links showing collect dialog

### DIFF
--- a/src/components/ExternalDrop/ExternalDrop.tsx
+++ b/src/components/ExternalDrop/ExternalDrop.tsx
@@ -32,7 +32,7 @@ export const ExternalDrop: FC<ExternalDropProps> = ({
   }
 
   if (status === 'ended') {
-    if (props.contractAddress === '0x') {
+    if (props.contractAddress === '0x' || props.contractAddress === '0x0') {
       return (
         <ExternalLinkButton
           partner={props.partner}


### PR DESCRIPTION
## Description
Some external links were showing collect dialog rather than link.

### Before
<img width="1512" alt="Screen Shot 2023-08-24 at 2 43 23 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/2f10ea20-ffe1-4e6d-a89b-8db9a9460630">

### After
<img width="1398" alt="Screen Shot 2023-08-24 at 2 43 40 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/383e14c0-9eb1-42bc-b6d9-83ac8816d4e1">
