### PR TITLE
fix: line-clamp on safari

### DIFF
--- a/src/components/TweetCard/TweetCard.tsx
+++ b/src/components/TweetCard/TweetCard.tsx
@@ -63,17 +63,19 @@ export const TweetCard: FunctionComponent<ITweetCardProps> = ({
             </div>
           </div>
         </div>
-        <div
-          className={clsx('my-2.5', {
-            'line-clamp-6': !!media || !!url,
-          })}
-        >
+        <div className={clsx('my-2.5 line-clamp-3')}>
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
-              p: ({ node, ...props }) => <p {...props} className="mb-3" />,
+              p: ({ node, ...props }) => (
+                <p {...props} className="mb-3 inline-block" />
+              ),
               a: ({ node, ...props }) => (
-                <a {...props} className="text-ocs-blue" target="_blank" />
+                <a
+                  {...props}
+                  className="text-ocs-blue"
+                  target="_blank inline-block"
+                />
               ),
             }}
           >
@@ -103,7 +105,7 @@ export const TweetCard: FunctionComponent<ITweetCardProps> = ({
           <div className="rounded-3xl border mt-auto">
             <img
               src={url?.images?.[0]?.url || ''}
-              className="rounded-t-3xl object-cover aspect-[4/2]"
+              className="rounded-t-3xl object-cover aspect-[4/2] w-full"
               alt={url?.title || ''}
             />
             <div className="bg-gray-200 rounded-b-3xl p-3">

--- a/src/components/TweetCard/TweetCard.tsx
+++ b/src/components/TweetCard/TweetCard.tsx
@@ -71,11 +71,7 @@ export const TweetCard: FunctionComponent<ITweetCardProps> = ({
                 <p {...props} className="mb-3 inline-block" />
               ),
               a: ({ node, ...props }) => (
-                <a
-                  {...props}
-                  className="text-ocs-blue"
-                  target="_blank inline-block"
-                />
+                <a {...props} className="text-ocs-blue" target="_blank" />
               ),
             }}
           >


### PR DESCRIPTION
## Description
On safari line-clamp won't work unless all children are `inline` which isn't great.

This PR is a compromise.

### Chrome
<img width="1349" alt="Screen Shot 2023-08-24 at 11 45 13 AM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/8d9fcbf4-ebab-4266-95ae-1a6fe3036575">

### Safari
<img width="1325" alt="Screen Shot 2023-08-24 at 3 06 05 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/51837850/79176da4-f137-4cdf-bf7b-429fa2b0df6d">
