### PR TITLE
chore: add Rainbow success CTA link / text and correct Atari digest ID

### DIFF
--- a/src/config/partners/atari.ts
+++ b/src/config/partners/atari.ts
@@ -11,7 +11,7 @@ const atari: Partner = {
   brandColor: 'rgb(209,66,65)',
   icon: '/partners/atari/icon.png',
   banner: '/partners/atari/banner-icon.svg',
-  aarweaveDigest: 'UD3mCdsfAiOoTqpuccjP13MusI9abvqqQn4gbKpqa24',
+  aarweaveDigest: 'N-zdPR5w0qhkgOFi9WJBDEnM2WzD4xfSHjF40i4qvq4',
   twitter: '@atari',
   drops: [
     {

--- a/src/config/partners/rainbow-wallet.ts
+++ b/src/config/partners/rainbow-wallet.ts
@@ -35,6 +35,10 @@ Become a Citizen in RainbowWorld, a new universe on BASE powered by Adworld.
       startDate: Date.UTC(2023, 7, 26, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       endDate: Date.UTC(2023, 7, 30, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       price: '0.01 ETH',
+      interactWithNFTLink: {
+        url: 'https://adworld.game/create',
+        label: 'Customize Your Citizen',
+      },
     },
     {
       image: 'https://assets.onchainsummer.xyz/Final_Art-CharacterCreator.gif',


### PR DESCRIPTION
## Description

Added mint-success secondary CTA for Rainbow linking to: https://adworld.game/create

<img width="1332" alt="It's Yours!" src="https://github.com/base-org/onchainsummer.xyz/assets/41811693/88098aa0-c713-4203-a161-b2f04b3b3318">
<img width="352" alt="It's Yours!" src="https://github.com/base-org/onchainsummer.xyz/assets/41811693/58e29610-501a-423e-a7e8-adc74f639885">
