### PR TITLE
feat: disable CTAs for info drops without links

### DIFF
--- a/src/components/ExternalLinkButton/ExternalLinkButton.tsx
+++ b/src/components/ExternalLinkButton/ExternalLinkButton.tsx
@@ -19,13 +19,14 @@ export const ExternalLinkButton: FC<ExternalLinkButtonProps> = ({
     try {
       href = new URL(externalLink).origin
       message = `View on ${partner}`
+      return (
+        <Button size={size} href={href} external>
+          <>
+            {message} <RightArrow fill="white" className="ml-auto" />
+          </>
+        </Button>
+      )
     } catch (e) {}
   }
-  return (
-    <Button size={size} href={href} external>
-      <>
-        {message} <RightArrow fill="white" className="ml-auto" />
-      </>
-    </Button>
-  )
+  return null
 }

--- a/src/config/partners/open-sea.ts
+++ b/src/config/partners/open-sea.ts
@@ -68,7 +68,7 @@ const openSeaConfig: Partner = {
       startDate: Date.UTC(2023, 7, 29, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       endDate: Date.UTC(2023, 7, 31, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       price: '0.009',
-      externalLink: 'https://opensea.io/collection/zwist-ocs/dro',
+      externalLink: 'https://opensea.io/collection/zwist-ocs/drop',
     },
   ],
 }

--- a/src/config/partners/open-sea.ts
+++ b/src/config/partners/open-sea.ts
@@ -26,7 +26,6 @@ const openSeaConfig: Partner = {
       startDate: Date.UTC(2023, 7, 29, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       endDate: Date.UTC(2023, 7, 31, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       price: '0',
-      externalLink: 'https://opensea.io',
     },
     {
       image: 'https://assets.onchainsummer.xyz/Jessica_Yatrofsky_2.png',
@@ -69,7 +68,7 @@ const openSeaConfig: Partner = {
       startDate: Date.UTC(2023, 7, 29, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       endDate: Date.UTC(2023, 7, 31, CAMPAIGN_HOUR, CAMPAIGN_MINUTE, 0, 0),
       price: '0.009',
-      externalLink: 'https://opensea.io/collection/zwist-ocs/drop',
+      externalLink: 'https://opensea.io/collection/zwist-ocs/dro',
     },
   ],
 }


### PR DESCRIPTION
## Description

Removed the main CTA for "info drops" that don't have an external link. This lets us remove the external link and have the button disappear (e.g. for Opensea) while not affecting other drop types.

Native Mint:
<img width="767" alt="image" src="https://github.com/base-org/onchainsummer.xyz/assets/41811693/99a68d23-20b9-4519-8c65-93a7d932e387">

External Mint (with a link):
<img width="841" alt="image" src="https://github.com/base-org/onchainsummer.xyz/assets/41811693/1e294e01-bbe9-4b0d-9ff9-0c940030ecdc">

External Mint (without a link):
<img width="676" alt="image" src="https://github.com/base-org/onchainsummer.xyz/assets/41811693/d4917ca9-50ee-4f85-afa6-8c04066ecf1c">
