### PR TITLE
chore: rename lenster to hey

### DIFF
--- a/src/components/Share/Share.tsx
+++ b/src/components/Share/Share.tsx
@@ -8,7 +8,7 @@ import { Lens } from '@/components/icons/Lens'
 
 const twitterURL: string = 'https://twitter.com/intent/tweet'
 const warpCastURL: string = 'https://warpcast.com'
-const lensURL: string = 'https://lenster.xyz'
+const lensURL: string = 'https://hey.xyz'
 
 type ShareComponentProps = {}
 export const Share: FC<ShareComponentProps> = () => {


### PR DESCRIPTION
We just rebranded lenster.xyz to hey.xyz

https://twitter.com/heydotxyz/status/1707431312385253477