### PR TITLE
chore: add basic frame for onchainsummer dot xyz

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "generate": "yarn graphql-codegen --config codegen.ts"
   },
   "dependencies": {
+    "@coinbase/onchainkit": "^0.6.1",
     "@commitlint/cli": "^17.6.5",
     "@crossmint/client-sdk-react-ui": "^1.0.1-alpha.4",
     "@eth-optimism/sdk": "^0.0.0-develop-20230720165249",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { Navbar } from '@/components/Navbar'
 import { TeaserNav } from '@/components/Teaser/TeaserNav'
 import { Footer } from '@/components/Footer'
 import Script from 'next/script'
+import { getFrameMetadata } from '@coinbase/onchainkit';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 
@@ -108,6 +109,22 @@ const SHOW_TEASER = process.env.TEASER === 'true'
 const MIRROR_SUBSCRIBE_URL = process.env.MIRROR_SUBSCRIBE_URL
 const MIRROR_PROJECT_ADDRESS = process.env.MIRROR_PROJECT_ADDRESS
 
+const frameMetadata = getFrameMetadata({
+  buttons: [
+    {
+      action: 'link',
+      label: 'Trending',
+      target: 'https://onchainsummer.xyz/trending',
+    },
+    {
+      action: 'link',
+      label: 'Community',
+      target: 'https://onchainsummer.xyz/community',
+    },
+  ],
+  image: website.logo.url,
+});
+
 export const metadata = {
   title: {
     template: `%s | ${website.siteName}`,
@@ -148,6 +165,9 @@ export const metadata = {
     site: website.twitter.site,
     creator: website.twitter.creator,
     images: [website.logo.url],
+  },
+  other: {
+    ...frameMetadata
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,6 +540,11 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
+"@coinbase/onchainkit@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@coinbase/onchainkit/-/onchainkit-0.6.1.tgz#fb14f99777eaba1a18ffea2575bca27a9ba2eaee"
+  integrity sha512-bkn0nB+gOKAi87UMUjfEJlgAa4IhiB5baaQkmWHru+6F0cugNtiam91Ci2l9bo3dhaP8Bxqx2fsv0MWMN7rGBg==
+
 "@coinbase/wallet-sdk@^3.6.6":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz#44b3b7a925ff5cc974e4cbf7a44199ffdcf03541"


### PR DESCRIPTION
## Description

Add a basic Farcaster Frame to onchainsummer.xyz using OnchainKit.

When a link to onchainsummer.xyz is shared on Farcaster, a Frame displaying the `og:image` and two buttons (1. Trending: links to trending page. 2. Community: links to community page will be displayed).

## Deploy Notes

Notes regarding deployment of the contained body of work. These should note any
db migrations, nginx routes, infrastructure changes, and anything that must be done before deployment.

- [ ] Need to add environment variables
  - `ENV_VAR=`

## Screenshots (if appropriate)

<img width="427" alt="Screenshot 2024-02-12 at 5 15 16 PM" src="https://github.com/base-org/onchainsummer.xyz/assets/3264051/4f703306-ac50-43a8-bd21-ecf13c1b6f82">

<!--- drag&drop screenshots here -->
